### PR TITLE
feat: adding shutter option as ros parameter

### DIFF
--- a/picamera_ros2/include/picamera_ros2/picamera_pub.hpp
+++ b/picamera_ros2/include/picamera_ros2/picamera_pub.hpp
@@ -29,6 +29,7 @@ private:
     int framerate_;
     bool verbose_;
     bool hdr_;
+    float shutter_;
 
     rclcpp::TimerBase::SharedPtr timer_;
     rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr image_pub_;

--- a/picamera_ros2/launch/camera.launch.py
+++ b/picamera_ros2/launch/camera.launch.py
@@ -26,6 +26,11 @@ def generate_launch_description():
             default_value="30",
             description="Framerate of the video stream."
         ),
+        DeclareLaunchArgument(
+            "shutter",
+            default_value="100.0",
+            description="Shutter speed of the camera in milliseconds."
+        ),
     ]
 
     container = ComposableNodeContainer(

--- a/picamera_ros2/src/picamera_pub.cpp
+++ b/picamera_ros2/src/picamera_pub.cpp
@@ -12,17 +12,20 @@ PiCameraROS::PiCameraROS(const rclcpp::NodeOptions &options_): Node("picamera_ro
     this->declare_parameter("framerate", 30);
     this->declare_parameter("hdr", true);
     this->declare_parameter("verbose", false);
+    this->declare_parameter("shutter", 100.0);
 
     this->get_parameter("video_width", this->video_width_);
     this->get_parameter("video_height", this->video_height_);
     this->get_parameter("framerate", this->framerate_);
     this->get_parameter("hdr", this->hdr_);
     this->get_parameter("verbose", this->verbose_);
+    this->get_parameter("shutter", this->shutter_);
 
     this->camera_->options->video_width = this->video_width_;
     this->camera_->options->video_height = this->video_height_;
     this->camera_->options->framerate = this->framerate_;
     this->camera_->options->verbose = this->verbose_;
+    this->camera_->options->shutter = this->shutter_;
 
     this->camera_->hdrOpen(this->hdr_);
     this->camera_->startVideo();


### PR DESCRIPTION
Adding `shutter` option as ROS parameter.
This enable to control exposure time when using `getVideoFrame()`.